### PR TITLE
Avoid setting local bundle path twice

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ in mkShell {
   in ''
     if [ -z "$BUNDLE_PATH" ]; then
       export BUNDLE_PATH=.bundle/${environmentId}
-    else
+    elif [ "$BUNDLE_PATH" != ".bundle/${environmentId}" ]; then
       export BUNDLE_PATH=$BUNDLE_PATH/${environmentId}
     fi
   '' + lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
This can happen whenever nix-shell is run from within a direnv loaded shell or a nix-shell. E.G.

    $ nix-shell
    $ echo $BUNDLE_PATH
    .bundle/cpq7h6vsbq4d1sgvqqg8df6jvnw60knh-environment
    $ nix-shell # Going one level deeper
    $ echo $BUNDLE_PATH
    .bundle/cpq7h6vsbq4d1sgvqqg8df6jvnw60knh-environment/.bundle/cpq7h6vsbq4d1sgvqqg8df6jvnw60knh-environment

This has previsouly just been a little annoying. But if we want to add scripts to the TLW/TLW way repo that use nix-shell as an interpreter then it gets us into a bit of trouble. More specifically I'm trying to add to the shellHook in TLW/TLW something that will make users of Rubymine able to have a better time. We may want to set the bundle path config on every shell load, this will allow Rubymine to find the path in the .bundle/config file. I also added a niv script that used a nix-shell interpreter. Whenever I ran the niv script, the BUNDLE_PATH would be doubled up (ends up the interpreter will use our shell.nix, TIL). When it did that it _also_ put that wrong doubled up value into the .bundle/config file (oh no!).

This change should mean that if we've set the $BUNDLE_PATH to the local location (the one we use in dev), it won't be set again. If however it's been set to anything else we'll add the local path on the end.